### PR TITLE
React Native fix from Java 1.0.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,7 @@ allprojects {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.github.doordeck:doordeck-sdk-java:1.0.2'
+    implementation 'com.github.doordeck:doordeck-sdk-java:1.0.3'
     implementation 'com.google.guava:guava:28.0-android'
 }
 

--- a/android/src/main/java/com/doordeck/RNDoordeckSdkModule.java
+++ b/android/src/main/java/com/doordeck/RNDoordeckSdkModule.java
@@ -8,6 +8,7 @@ import com.doordeck.sdk.common.events.UnlockCallback;
 import com.doordeck.sdk.common.manager.Doordeck;
 import com.doordeck.sdk.common.manager.ScanType;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.doordeck.sdk.ui.verify.VerifyDeviceActivity;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
@@ -28,6 +29,11 @@ public class RNDoordeckSdkModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void initDoordeck(String authToken) {
         Doordeck.INSTANCE.initialize(getReactApplicationContext(), authToken, false);
+    }
+
+    @ReactMethod
+    public void initDoordeckWithDarkMode(String authToken, boolean darkMode) {
+        Doordeck.INSTANCE.initialize(getReactApplicationContext(), authToken, darkMode);
     }
 
     @ReactMethod
@@ -62,6 +68,11 @@ public class RNDoordeckSdkModule extends ReactContextBaseJavaModule {
             @Override
             public void notAuthenticated() {
 
+            }
+
+            @Override
+            public void verificationNeeded() {
+                VerifyDeviceActivity.Companion.start(getReactApplicationContext());
             }
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@doordeck/react-native-doordeck-sdk",
   "title": "React Native Doordeck Sdk",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "React Native wrapper for the Doordeck SDK.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes with the native library and add one more initialization method (can't have the same name though!).

Added the new version so you can publish in NPM already.