### PR TITLE
Change of bridge architecture & fixes & closeButton

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Coming soon - see manual install for now
 		
 		platform :ios, "10.0"
 		pod "QRCodeReader.swift", "~> 10.0"
-		pod "ReachabilitySwift", "~> 4.3"
+		pod "ReachabilitySwift", "~> 5.0.0"
 		pod "Alamofire", "~> 4.8"
 		pod "Cache", "~> 5.2"
 		pod "Sodium", "~> 0.8"

--- a/android/src/main/java/com/doordeck/RNDoordeckSdkModule.java
+++ b/android/src/main/java/com/doordeck/RNDoordeckSdkModule.java
@@ -26,13 +26,11 @@ public class RNDoordeckSdkModule extends ReactContextBaseJavaModule {
         return "RNDoordeckSdk";
     }
 
+    /**
+     ** @param closeButton isn't used but the signature has to match with the Javascript bridge and the iOS SDK
+     **/
     @ReactMethod
-    public void initDoordeck(String authToken) {
-        Doordeck.INSTANCE.initialize(getReactApplicationContext(), authToken, false);
-    }
-
-    @ReactMethod
-    public void initDoordeckWithDarkMode(String authToken, boolean darkMode) {
+    public void initDoordeck(String authToken, boolean darkMode, boolean closeButton) {
         Doordeck.INSTANCE.initialize(getReactApplicationContext(), authToken, darkMode);
     }
 

--- a/index.js
+++ b/index.js
@@ -2,4 +2,12 @@ import { NativeModules } from 'react-native';
 
 const { RNDoordeckSdk } = NativeModules;
 
-export default RNDoordeckSdk;
+const logout = () => RNDoordeckSdk.logout();
+const initDoordeck = (authToken, darkMode = true, closeButton = false) => RNDoordeckSdk.initDoordeck(authToken, darkMode, closeButton);
+const showUnlock = () => RNDoordeckSdk.showUnlock();
+
+module.exports = {
+    logout,
+    initDoordeck,
+    showUnlock
+}

--- a/ios/doordeck-sdk/RNDoordeckSdk.m
+++ b/ios/doordeck-sdk/RNDoordeckSdk.m
@@ -10,7 +10,7 @@
 {
     return YES;
 }
-RCT_EXTERN_METHOD(initDoordeck:(NSString *)auth)
+RCT_EXTERN_METHOD(initDoordeck:(NSString *)auth withDarkMode:(BOOL)darkMode withCloseButton:(BOOL)closeButton)
 RCT_EXTERN_METHOD(showUnlock)
 @end
 

--- a/ios/doordeck-sdk/RNDoordeckSdk.m
+++ b/ios/doordeck-sdk/RNDoordeckSdk.m
@@ -10,7 +10,7 @@
 {
     return YES;
 }
-RCT_EXTERN_METHOD(initDoordeck:(NSString *)auth withDarkMode:(BOOL)darkMode withCloseButton:(BOOL)closeButton)
+RCT_EXTERN_METHOD(initDoordeck:(NSString *)auth darkMode:(BOOL)darkMode closeButton:(BOOL)closeButton)
 RCT_EXTERN_METHOD(showUnlock)
 @end
 

--- a/ios/doordeck-sdk/RNDoordeckSdk.swift
+++ b/ios/doordeck-sdk/RNDoordeckSdk.swift
@@ -5,9 +5,9 @@ class RNDoordeckSdk: NSObject {
   
   private var doordeck: Doordeck! = nil
   
-  @objc func initDoordeck(_ auth: String) {
+  @objc func initDoordeck(_ auth: String, darkMode: Bool = true, closeButton: Bool = false) {
     let authToken = AuthTokenClass(auth)
-    doordeck = Doordeck(authToken)
+    doordeck = Doordeck(authToken, darkMode, closeButton)
     doordeck.delegate = self
     doordeck.Initialize()
   }

--- a/ios/doordeck-sdk/RNDoordeckSdk.swift
+++ b/ios/doordeck-sdk/RNDoordeckSdk.swift
@@ -7,7 +7,7 @@ class RNDoordeckSdk: NSObject {
   
   @objc func initDoordeck(_ auth: String, darkMode: Bool = true, closeButton: Bool = false) {
     let authToken = AuthTokenClass(auth)
-    doordeck = Doordeck(authToken, darkMode, closeButton)
+    doordeck = Doordeck(authToken, darkMode: darkMode, closeButton: closeButton)
     doordeck.delegate = self
     doordeck.Initialize()
   }

--- a/ios/doordeck-sdk/RNDoordeckSdk.swift
+++ b/ios/doordeck-sdk/RNDoordeckSdk.swift
@@ -13,11 +13,13 @@ class RNDoordeckSdk: NSObject {
   }
   
   @objc func showUnlock() {
-    if (doordeck != nil) {
-      doordeck.showUnlockScreen(success: {
-        print("success")
-      }) {
-        print("fail")
+    DispatchQueue.main.async {
+      if (self.doordeck != nil) {
+        self.doordeck.showUnlockScreen(success: {
+          print("success")
+        }) {
+          print("fail")
+        }
       }
     }
   }

--- a/ios/doordeck-sdk/doordeck-sdk-swift/Network/ReachabilityHelper.swift
+++ b/ios/doordeck-sdk/doordeck-sdk-swift/Network/ReachabilityHelper.swift
@@ -40,7 +40,7 @@ class ReachabilityHelper {
     
     /// Is there a Data connection
     var isConnected: Bool {
-        return reachability?.connection != Reachability.Connection.unavailable ? true : false
+        return reachability?.connection != Reachability.Connection.none ? true : false
     }
     
     /// Notification of Data drops

--- a/ios/doordeck-sdk/doordeck-sdk-swift/Network/ReachabilityHelper.swift
+++ b/ios/doordeck-sdk/doordeck-sdk-swift/Network/ReachabilityHelper.swift
@@ -40,7 +40,7 @@ class ReachabilityHelper {
     
     /// Is there a Data connection
     var isConnected: Bool {
-        return reachability?.connection != Reachability.Connection.none ? true : false
+        return reachability?.connection != Reachability.Connection.unavailable ? true : false
     }
     
     /// Notification of Data drops

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@doordeck/react-native-doordeck-sdk",
   "title": "React Native Doordeck Sdk",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "description": "React Native wrapper for the Doordeck SDK.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I've done the following things:
1.- I've changed how the SDK is exposed into Javascript.
I've closed the exposure of the SDK, and there will be only methods defined in the JS part. By doing this, optional values are possible. Signatures on Android and iOS have to be the same, and now with a normal IDE, you can see this:
![image](https://user-images.githubusercontent.com/6842786/72753907-84745000-3bc6-11ea-9c1d-4775f6e94d3d.png)

2.- I've set the `showUnlock` on iOS to be shown in the main thread. It seems to crash when I run it not on it (simulator).

3.- Changed the `Reachability.Connection.unavailable` because after a `pod update` or `pod install` (in that order and vice-versa), that parameter isn't defined.